### PR TITLE
Use an earlier callback to trigger LTI statement

### DIFF
--- a/statement/lti/lib.php
+++ b/statement/lti/lib.php
@@ -26,9 +26,9 @@
 use local_integrity\statement_factory;
 
 /**
- * Call back executed after require login.
+ * Call back executed after config loaded.
  */
-function integritystmt_lti_after_require_login() {
+function integritystmt_lti_after_config() {
     global $SCRIPT, $USER;
 
     if ($SCRIPT == '/mod/lti/launch.php') {

--- a/statement/lti/version.php
+++ b/statement/lti/version.php
@@ -27,6 +27,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'integritystmt_lti';
 $plugin->release = '0.1.0';
-$plugin->version = 2021072309;
+$plugin->version = 2021072310;
 $plugin->requires = 2020061500;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Looks like we need to trigger a logic earlier as in some cases (e.g. LTI 1.3) it redirects to /mod/lti/launch.php before logging in a user. 
