### PR TITLE
Default value for activity setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Once agreed in a context, the statement won't be displayed again, unless reset m
 * capabilities to change a default state for each of the statements (integritystmt/PLUGIN_NAME:changedefault);
 * capability to bypass statement notice (local/integrity:bypassnotice);
 * a CLI script to reset user data for a course, an activity, a statement plugin, a user or all data in a system;
+* a CLI script to set a default value in pre-existing activity setting to enable or disable the academic integrity;
 
 
 ## Supported activities ##

--- a/cli/default.php
+++ b/cli/default.php
@@ -25,7 +25,7 @@
 
 use local_integrity\plugininfo\integritystmt;
 use local_integrity\statement_factory;
-use \local_integrity\settings;
+use local_integrity\settings;
 
 define('CLI_SCRIPT', true);
 

--- a/cli/default.php
+++ b/cli/default.php
@@ -48,7 +48,8 @@ if ($unrecognized) {
     cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
 }
 
-if ($options['help']) {
+// Display help in case if requested for a help text or if unexpected default value is provided.
+if ($options['help'] || (!isset($options['default']) || !in_array($options['default'], ['enable', 'disable'], true))) {
     $help = <<<EOT
 Default value for academic integrity.
 

--- a/cli/default.php
+++ b/cli/default.php
@@ -18,7 +18,7 @@
  * CLI script for default settings value for activity.
  *
  * @package    local_integrity
- * @copyright  2021 Catalyst IT
+ * @copyright  2025 Catalyst IT
  * @author     Guillaume BARAT (guillaumebarat@catalyst-au.net)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -36,7 +36,7 @@ require_once($CFG->libdir . '/clilib.php');
         'default' => false,
         'help' => false,
     ],
-[
+    [
         'd' => 'default',
         'h' => 'help',
     ]
@@ -49,7 +49,7 @@ if ($unrecognized) {
 
 if ($options['help']) {
     $help = <<<EOT
-Reset integrity statement agreements.
+Default value for academic integrity.
 
 Options:
  -d, --default             Set default integrity settings for each activity that has not been set yet.

--- a/cli/default.php
+++ b/cli/default.php
@@ -1,0 +1,112 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * CLI script for default settings value for activity.
+ *
+ * @package    local_integrity
+ * @copyright  2021 Catalyst IT
+ * @author     Guillaume BARAT (guillaumebarat@catalyst-au.net)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use local_integrity\plugininfo\integritystmt;
+use local_integrity\statement_factory;
+
+define('CLI_SCRIPT', true);
+
+require(__DIR__ . '/../../../config.php');
+require_once($CFG->libdir . '/clilib.php');
+
+[$options, $unrecognized] = cli_get_params(
+    [
+        'default' => false,
+        'help' => false,
+    ],
+[
+        'd' => 'default',
+        'h' => 'help',
+    ]
+);
+
+if ($unrecognized) {
+    $unrecognized = implode("\n  ", $unrecognized);
+    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+}
+
+if ($options['help']) {
+    $help = <<<EOT
+Reset integrity statement agreements.
+
+Options:
+ -d, --default             Set default integrity settings for each activity that has not been set yet.
+
+Example:
+\$sudo -u www-data /usr/bin/php local/integrity/cli/default.php --default=0,1
+
+EOT;
+    cli_writeln($help);
+    exit(0);
+}
+
+if (isset($options['default']) && in_array($options['default'], [0, 1])) {
+    $enabled = $options['default'];
+    $stmt = statement_factory::get_statements();
+    $pluginlist = integritystmt::get_enabled_plugins();
+    foreach ($pluginlist as $name) {
+        $pluginstmt[$name] = $stmt[$name]->get_plugin_name();
+    }
+    [$insqlplugin, $paramsplugins] = $DB->get_in_or_equal(array_keys($pluginlist));
+    $courseids = $DB->get_records('course', null, 'id', 'id');
+    foreach ($courseids as $courseid) {
+        $coursecontext = context_course::instance($courseid->id, IGNORE_MISSING);
+        if (!empty($coursecontext)) {
+            $children = $coursecontext->get_child_contexts();
+            if (!empty($children)) {
+                [$insql, $params] = $DB->get_in_or_equal(array_keys($children));
+                $sql = "SELECT ct.id contextid, m.name modulename
+                            FROM {modules} m
+                            INNER JOIN {course_modules} cm ON m.id = cm.module
+                            INNER JOIN {context} ct ON ct.instanceid = cm.id
+                            WHERE ct.contextlevel = 70 AND cm.course = $courseid->id AND m.name $insqlplugin
+                            ";
+                $check = $DB->get_records_select(\local_integrity\settings::TABLE, "contextid $insql", $params);
+                $contextalreadysettup = [];
+                $datacontextplugins = $DB->get_records_sql($sql, $paramsplugins);
+                foreach ($check as $activity) {
+                    $contextalreadysettup[] = $activity->contextid;
+                }
+                $buildobject = [];
+                foreach ($datacontextplugins as $datacontext) {
+                    if (!in_array($datacontext->contextid, $contextalreadysettup)) {
+                        $buildobject[] = (object) [
+                                'id' => null,
+                                'contextid' => $datacontext->contextid,
+                                'plugin' => $pluginstmt[$datacontext->modulename],
+                                'enabled' => $enabled,
+                                'usermodified' => 2,
+                                'timecreated' => time(),
+                                'timemodified' => time(),
+                        ];
+                    }
+                }
+                $DB->insert_records(\local_integrity\settings::TABLE, $buildobject);
+            }
+        }
+    }
+    cli_writeln("Activity default setting all set.");
+}
+exit(0);

--- a/cli/default.php
+++ b/cli/default.php
@@ -53,6 +53,7 @@ Default value for academic integrity.
 
 Options:
  -d, --default             Set default integrity settings for each activity that has not been set yet.
+ -h, --help                Print out this help
 
 Example:
 \$sudo -u www-data /usr/bin/php local/integrity/cli/default.php --default=0,1
@@ -63,49 +64,41 @@ EOT;
 }
 
 if (isset($options['default']) && in_array($options['default'], [0, 1])) {
+    $integritytable = \local_integrity\settings::TABLE;
     $enabled = $options['default'];
     $stmt = statement_factory::get_statements();
     $pluginlist = integritystmt::get_enabled_plugins();
+    $pluginstmt = [];
     foreach ($pluginlist as $name) {
         $pluginstmt[$name] = $stmt[$name]->get_plugin_name();
     }
     [$insqlplugin, $paramsplugins] = $DB->get_in_or_equal(array_keys($pluginlist));
-    $courseids = $DB->get_records('course', null, 'id', 'id');
-    foreach ($courseids as $courseid) {
-        $coursecontext = context_course::instance($courseid->id, IGNORE_MISSING);
-        if (!empty($coursecontext)) {
-            $children = $coursecontext->get_child_contexts();
-            if (!empty($children)) {
-                [$insql, $params] = $DB->get_in_or_equal(array_keys($children));
-                $sql = "SELECT ct.id contextid, m.name modulename
-                            FROM {modules} m
-                            INNER JOIN {course_modules} cm ON m.id = cm.module
-                            INNER JOIN {context} ct ON ct.instanceid = cm.id
-                            WHERE ct.contextlevel = 70 AND cm.course = $courseid->id AND m.name $insqlplugin
-                            ";
-                $check = $DB->get_records_select(\local_integrity\settings::TABLE, "contextid $insql", $params);
-                $contextalreadysettup = [];
-                $datacontextplugins = $DB->get_records_sql($sql, $paramsplugins);
-                foreach ($check as $activity) {
-                    $contextalreadysettup[] = $activity->contextid;
-                }
-                $buildobject = [];
-                foreach ($datacontextplugins as $datacontext) {
-                    if (!in_array($datacontext->contextid, $contextalreadysettup)) {
-                        $buildobject[] = (object) [
-                                'id' => null,
-                                'contextid' => $datacontext->contextid,
-                                'plugin' => $pluginstmt[$datacontext->modulename],
-                                'enabled' => $enabled,
-                                'usermodified' => 2,
-                                'timecreated' => time(),
-                                'timemodified' => time(),
-                        ];
-                    }
-                }
-                $DB->insert_records(\local_integrity\settings::TABLE, $buildobject);
-            }
-        }
+    $sql = "SELECT ct.id contextid, m.name modulename
+                          FROM {modules} m
+                    INNER JOIN {course_modules} cm ON m.id = cm.module
+                    INNER JOIN {context} ct ON ct.instanceid = cm.id
+                     LEFT JOIN {" . $integritytable . "} lis ON lis.contextid = ct.id
+                         WHERE ct.contextlevel = 70
+                           AND m.name $insqlplugin
+                           AND lis.contextid IS NULL";
+    $datacontextplugins = $DB->get_recordset_sql($sql, $paramsplugins);
+    $buildobject = [];
+    foreach ($datacontextplugins as $datacontext) {
+        $buildobject[] = (object) [
+                'id' => null,
+                'contextid' => $datacontext->contextid,
+                'plugin' => $pluginstmt[$datacontext->modulename],
+                'enabled' => $enabled,
+                'usermodified' => 2,
+                'timecreated' => time(),
+                'timemodified' => time(),
+        ];
+    }
+    $datacontextplugins->close();
+    // Split the object in batch of 2000.
+    $chunks = array_chunk($buildobject, 2000);
+    foreach ($chunks as $chunk) {
+        $DB->insert_records($integritytable, $chunk);
     }
     cli_writeln("Activity default setting all set.");
 }

--- a/cli/default.php
+++ b/cli/default.php
@@ -25,6 +25,7 @@
 
 use local_integrity\plugininfo\integritystmt;
 use local_integrity\statement_factory;
+use \local_integrity\settings;
 
 define('CLI_SCRIPT', true);
 
@@ -33,7 +34,7 @@ require_once($CFG->libdir . '/clilib.php');
 
 [$options, $unrecognized] = cli_get_params(
     [
-        'default' => false,
+        'default' => null,
         'help' => false,
     ],
     [
@@ -56,16 +57,25 @@ Options:
  -h, --help                Print out this help
 
 Example:
-\$sudo -u www-data /usr/bin/php local/integrity/cli/default.php --default=0,1
+\$sudo -u www-data /usr/bin/php local/integrity/cli/default.php --default=enable,disable
 
 EOT;
     cli_writeln($help);
     exit(0);
 }
 
-if (isset($options['default']) && in_array($options['default'], [0, 1])) {
-    $integritytable = \local_integrity\settings::TABLE;
-    $enabled = $options['default'];
+if (isset($options['default']) && in_array($options['default'], ['enable', 'disable'], true)) {
+    $integritytable = settings::TABLE;
+    switch ($options['default']) {
+        case 'enable':
+            $enabled = 1;
+            break;
+        case 'disable':
+            $enabled = 0;
+            break;
+        default:
+            $enabled = null;
+    }
     $stmt = statement_factory::get_statements();
     $pluginlist = integritystmt::get_enabled_plugins();
     $pluginstmt = [];
@@ -82,24 +92,33 @@ if (isset($options['default']) && in_array($options['default'], [0, 1])) {
                            AND m.name $insqlplugin
                            AND lis.contextid IS NULL";
     $datacontextplugins = $DB->get_recordset_sql($sql, $paramsplugins);
-    $buildobject = [];
+    $batch = [];
+    $batchsize = 2000;
+    $time = time();
+    $insertedcount = 0;
     foreach ($datacontextplugins as $datacontext) {
-        $buildobject[] = (object) [
+        $batch[] = (object) [
                 'id' => null,
                 'contextid' => $datacontext->contextid,
                 'plugin' => $pluginstmt[$datacontext->modulename],
                 'enabled' => $enabled,
                 'usermodified' => 2,
-                'timecreated' => time(),
-                'timemodified' => time(),
+                'timecreated' => $time,
+                'timemodified' => $time,
         ];
+        // Insert batch once it reaches the limit.
+        if (count($batch) >= $batchsize) {
+            $DB->insert_records($integritytable, $batch);
+            $insertedcount += count($batch);
+            $batch = []; // Clean memory.
+        }
+    }
+    // Insert remaining records if any.
+    if (!empty($batch)) {
+        $DB->insert_records($integritytable, $batch);
+        $insertedcount += count($batch);
     }
     $datacontextplugins->close();
-    // Split the object in batch of 2000.
-    $chunks = array_chunk($buildobject, 2000);
-    foreach ($chunks as $chunk) {
-        $DB->insert_records($integritytable, $chunk);
-    }
-    cli_writeln("Activity default setting all set.");
+    cli_writeln("Activity default setting of $enabled was set for $insertedcount activities");
 }
 exit(0);

--- a/cli/reset.php
+++ b/cli/reset.php
@@ -91,14 +91,15 @@ if (isset($options['default']) && in_array($options['default'], [0, 1])) {
     foreach ($pluginlist as $name) {
         $pluginstmt[$name] = $stmt[$name]->get_plugin_name();
     }
-    list($insqlplugin, $paramsplugins) = $DB->get_in_or_equal(array_keys($pluginlist));
+    [$insqlplugin, $paramsplugins] = $DB->get_in_or_equal(array_keys($pluginlist));
+    exit;
     $courseids = $DB->get_records('course', null, 'id', 'id');
     foreach ($courseids as $courseid) {
         $coursecontext = context_course::instance($courseid->id, IGNORE_MISSING);
         if (!empty($coursecontext)) {
             $children = $coursecontext->get_child_contexts();
             if (!empty($children)) {
-                list($insql, $params) = $DB->get_in_or_equal(array_keys($children));
+                [$insql, $params] = $DB->get_in_or_equal(array_keys($children));
                 $sql = "SELECT ct.id contextid, m.name modulename
                             FROM {modules} m
                             INNER JOIN {course_modules} cm ON m.id = cm.module

--- a/cli/reset.php
+++ b/cli/reset.php
@@ -32,24 +32,24 @@ require(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/clilib.php');
 
 [$options, $unrecognized] = cli_get_params(
-        [
-                'all' => false,
-                'courseids' => false,
-                'cmids' => false,
-                'userids' => false,
-                'plugins' => false,
-                'default' => false,
-                'help' => false
-        ],
-        [
-                'a' => 'all',
-                'c' => 'courseids',
-                'm' => 'cmids',
-                'u' => 'userids',
-                'p' => 'plugins',
-                'd' => 'default',
-                'h' => 'help'
-        ]
+    [
+        'all' => false,
+        'courseids' => false,
+        'cmids' => false,
+        'userids' => false,
+        'plugins' => false,
+        'default' => false,
+        'help' => false,
+    ],
+    [
+        'a' => 'all',
+        'c' => 'courseids',
+        'm' => 'cmids',
+        'u' => 'userids',
+        'p' => 'plugins',
+        'd' => 'default',
+        'h' => 'help',
+    ]
 );
 
 if ($unrecognized) {
@@ -84,7 +84,7 @@ EOT;
     exit(0);
 }
 
-if (isset($options['default']) && in_array($options['default'], [0,1])) {
+if (isset($options['default']) && in_array($options['default'], [0, 1])) {
     $enabled = $options['default'];
     $stmt = statement_factory::get_statements();
     $pluginlist = integritystmt::get_enabled_plugins();
@@ -113,7 +113,7 @@ if (isset($options['default']) && in_array($options['default'], [0,1])) {
                 }
                 $buildobject = [];
                 foreach ($datacontextplugins as $datacontext) {
-                    if(!in_array($datacontext->contextid, $contextalreadysettup)) {
+                    if (!in_array($datacontext->contextid, $contextalreadysettup)) {
                         $buildobject[] = (object) [
                                 'id' => null,
                                 'contextid' => $datacontext->contextid,

--- a/cli/reset.php
+++ b/cli/reset.php
@@ -23,9 +23,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use local_integrity\plugininfo\integritystmt;
-use local_integrity\statement_factory;
-
 define('CLI_SCRIPT', true);
 
 require(__DIR__ . '/../../../config.php');
@@ -38,7 +35,6 @@ require_once($CFG->libdir . '/clilib.php');
         'cmids' => false,
         'userids' => false,
         'plugins' => false,
-        'default' => false,
         'help' => false,
     ],
     [
@@ -47,7 +43,6 @@ require_once($CFG->libdir . '/clilib.php');
         'm' => 'cmids',
         'u' => 'userids',
         'p' => 'plugins',
-        'd' => 'default',
         'h' => 'help',
     ]
 );
@@ -68,7 +63,6 @@ Options:
  -m, --cmids               Comma delimited list of course module IDs to reset statements for.
  -u, --userids             Comma delimited list of user IDs to reset all statements for.
  -p, --plugins             Comma delimited list of statement plugins to reset data for.
- -d, --default             Set default integrity settings for each activity that has not been set yet.
 
 Example:
 \$sudo -u www-data /usr/bin/php local/integrity/cli/reset.php --all
@@ -76,61 +70,10 @@ Example:
 \$sudo -u www-data /usr/bin/php local/integrity/cli/reset.php --cmids=5,17,14
 \$sudo -u www-data /usr/bin/php local/integrity/cli/reset.php --userids=2,19
 \$sudo -u www-data /usr/bin/php local/integrity/cli/reset.php --plugins=integritystmt_forum,integritystmt_assign
-\$sudo -u www-data /usr/bin/php local/integrity/cli/reset.php --default=0,1
 
 
 EOT;
     cli_writeln($help);
-    exit(0);
-}
-
-if (isset($options['default']) && in_array($options['default'], [0, 1])) {
-    $enabled = $options['default'];
-    $stmt = statement_factory::get_statements();
-    $pluginlist = integritystmt::get_enabled_plugins();
-    foreach ($pluginlist as $name) {
-        $pluginstmt[$name] = $stmt[$name]->get_plugin_name();
-    }
-    [$insqlplugin, $paramsplugins] = $DB->get_in_or_equal(array_keys($pluginlist));
-    exit;
-    $courseids = $DB->get_records('course', null, 'id', 'id');
-    foreach ($courseids as $courseid) {
-        $coursecontext = context_course::instance($courseid->id, IGNORE_MISSING);
-        if (!empty($coursecontext)) {
-            $children = $coursecontext->get_child_contexts();
-            if (!empty($children)) {
-                [$insql, $params] = $DB->get_in_or_equal(array_keys($children));
-                $sql = "SELECT ct.id contextid, m.name modulename
-                            FROM {modules} m
-                            INNER JOIN {course_modules} cm ON m.id = cm.module
-                            INNER JOIN {context} ct ON ct.instanceid = cm.id
-                            WHERE ct.contextlevel = 70 AND cm.course = $courseid->id AND m.name $insqlplugin
-                            ";
-                $check = $DB->get_records_select(\local_integrity\settings::TABLE, "contextid $insql", $params);
-                $contextalreadysettup = [];
-                $datacontextplugins = $DB->get_records_sql($sql, $paramsplugins);
-                foreach ($check as $activity) {
-                    $contextalreadysettup[] = $activity->contextid;
-                }
-                $buildobject = [];
-                foreach ($datacontextplugins as $datacontext) {
-                    if (!in_array($datacontext->contextid, $contextalreadysettup)) {
-                        $buildobject[] = (object) [
-                                'id' => null,
-                                'contextid' => $datacontext->contextid,
-                                'plugin' => $pluginstmt[$datacontext->modulename],
-                                'enabled' => $enabled,
-                                'usermodified' => 2,
-                                'timecreated' => time(),
-                                'timemodified' => time(),
-                        ];
-                    }
-                }
-                $DB->insert_records(\local_integrity\settings::TABLE, $buildobject);
-            }
-        }
-    }
-    cli_writeln("Activity default setting all set.");
     exit(0);
 }
 

--- a/cli/reset.php
+++ b/cli/reset.php
@@ -23,28 +23,33 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use local_integrity\plugininfo\integritystmt;
+use local_integrity\statement_factory;
+
 define('CLI_SCRIPT', true);
 
 require(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/clilib.php');
 
 [$options, $unrecognized] = cli_get_params(
-    [
-        'all' => false,
-        'courseids' => false,
-        'cmids' => false,
-        'userids' => false,
-        'plugins' => false,
-        'help' => false,
-    ],
-    [
-        'a' => 'all',
-        'c' => 'courseids',
-        'm' => 'cmids',
-        'u' => 'userids',
-        'p' => 'plugins',
-        'h' => 'help',
-    ]
+        [
+                'all' => false,
+                'courseids' => false,
+                'cmids' => false,
+                'userids' => false,
+                'plugins' => false,
+                'default' => false,
+                'help' => false
+        ],
+        [
+                'a' => 'all',
+                'c' => 'courseids',
+                'm' => 'cmids',
+                'u' => 'userids',
+                'p' => 'plugins',
+                'd' => 'default',
+                'h' => 'help'
+        ]
 );
 
 if ($unrecognized) {
@@ -63,6 +68,7 @@ Options:
  -m, --cmids               Comma delimited list of course module IDs to reset statements for.
  -u, --userids             Comma delimited list of user IDs to reset all statements for.
  -p, --plugins             Comma delimited list of statement plugins to reset data for.
+ -d, --default             Set default integrity settings for each activity that has not been set yet.
 
 Example:
 \$sudo -u www-data /usr/bin/php local/integrity/cli/reset.php --all
@@ -70,10 +76,60 @@ Example:
 \$sudo -u www-data /usr/bin/php local/integrity/cli/reset.php --cmids=5,17,14
 \$sudo -u www-data /usr/bin/php local/integrity/cli/reset.php --userids=2,19
 \$sudo -u www-data /usr/bin/php local/integrity/cli/reset.php --plugins=integritystmt_forum,integritystmt_assign
+\$sudo -u www-data /usr/bin/php local/integrity/cli/reset.php --default=0,1
 
 
 EOT;
     cli_writeln($help);
+    exit(0);
+}
+
+if (isset($options['default']) && in_array($options['default'], [0,1])) {
+    $enabled = $options['default'];
+    $stmt = statement_factory::get_statements();
+    $pluginlist = integritystmt::get_enabled_plugins();
+    foreach ($pluginlist as $name) {
+        $pluginstmt[$name] = $stmt[$name]->get_plugin_name();
+    }
+    list($insqlplugin, $paramsplugins) = $DB->get_in_or_equal(array_keys($pluginlist));
+    $courseids = $DB->get_records('course', null, 'id', 'id');
+    foreach ($courseids as $courseid) {
+        $coursecontext = context_course::instance($courseid->id, IGNORE_MISSING);
+        if (!empty($coursecontext)) {
+            $children = $coursecontext->get_child_contexts();
+            if (!empty($children)) {
+                list($insql, $params) = $DB->get_in_or_equal(array_keys($children));
+                $sql = "SELECT ct.id contextid, m.name modulename
+                            FROM {modules} m
+                            INNER JOIN {course_modules} cm ON m.id = cm.module
+                            INNER JOIN {context} ct ON ct.instanceid = cm.id
+                            WHERE ct.contextlevel = 70 AND cm.course = $courseid->id AND m.name $insqlplugin
+                            ";
+                $check = $DB->get_records_select(\local_integrity\settings::TABLE, "contextid $insql", $params);
+                $contextalreadysettup = [];
+                $datacontextplugins = $DB->get_records_sql($sql, $paramsplugins);
+                foreach ($check as $activity) {
+                    $contextalreadysettup[] = $activity->contextid;
+                }
+                $buildobject = [];
+                foreach ($datacontextplugins as $datacontext) {
+                    if(!in_array($datacontext->contextid, $contextalreadysettup)) {
+                        $buildobject[] = (object) [
+                                'id' => null,
+                                'contextid' => $datacontext->contextid,
+                                'plugin' => $pluginstmt[$datacontext->modulename],
+                                'enabled' => $enabled,
+                                'usermodified' => 2,
+                                'timecreated' => time(),
+                                'timemodified' => time(),
+                        ];
+                    }
+                }
+                $DB->insert_records(\local_integrity\settings::TABLE, $buildobject);
+            }
+        }
+    }
+    cli_writeln("Activity default setting all set.");
     exit(0);
 }
 


### PR DESCRIPTION
After adding the plugin, existing activity would be affected only if we manually visit and update the activity setting. 
This script update allow to force to enable or disable the academic integrity for every not yet set activity.
